### PR TITLE
WIP: Make IAM role and instance_type variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -40,7 +40,7 @@ resource "aws_eks_node_group" "default" {
 }
 
 resource "aws_iam_role" "default" {
-  name = "RoleEksCluster"
+  name = "RoleEksCluster-${var.name}"
   tags = var.tags
 
   assume_role_policy = jsonencode(
@@ -58,7 +58,7 @@ resource "aws_iam_role" "default" {
 }
 
 resource "aws_iam_role" "default_node_group" {
-  name = "RoleEksClusterNodeGroup"
+  name = "RoleEksClusterNodeGroup-${var.name}"
   tags = var.tags
 
   assume_role_policy = jsonencode({

--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ resource "aws_eks_cluster" "default" {
 
 resource "aws_eks_node_group" "default" {
   cluster_name    = aws_eks_cluster.default.name
-  instance_types  = ["t3.small"]
+  instance_types  = var.instance_types
   node_group_name = "default_node"
   node_role_arn   = aws_iam_role.default_node_group.arn
   subnet_ids      = var.subnet_ids

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,12 @@ variable "log_retention" {
   description = "Retention of CloudWatch logs for the EKS cluster"
 }
 
+variable "instance_types" {
+  type        = list(string)
+  default     = null
+  description = "List of EC2 instance types to use for the worker nodes"
+}
+
 variable "name" {
   type        = string
   description = "Name of the cluster"


### PR DESCRIPTION
This PR makes the IAM role variable to deploy multiple EKS clusters in one account and allows you to specify the instance_types to be used.